### PR TITLE
Disable $wgShowIPinHeader

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -359,6 +359,7 @@ $wgResourceLoaderMaxage['unversioned']['client'] = 60 * 60 * 24; // cache uncach
 $wgEnableSidebarCache = false; // don't cache the sidebar (MediaWikiChat adds a module)
 $wgUseFileCache = true;
 $wgFileCacheDirectory = "$IP/cache/$bmProject"; // show IPs fully cached html pages
+$wgShowIPinHeader = false; // speeds up page loads and makes file cache more effective
 
 $wgDBerrorLog = "$IP/DB.log";
 


### PR DESCRIPTION
This will make the (file) cache more effective and probably increase performance. Also, random IPs show when you try to view any page - not very good!